### PR TITLE
ci: try testing jiffy with this and next Go versions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,5 +16,3 @@ concurrency:
 jobs:
   go-test:
     uses: pl-strflt/uci/.github/workflows/go-test.yml@v0.0
-    with:
-      go-versions: '["this"]'


### PR DESCRIPTION
We could try using the default and testing the repo both with this (1.20) and the next (1.21) Go versions.